### PR TITLE
Add Sanskrit metrical poetry composition RL environment

### DIFF
--- a/configs/inference/sanskrit_poetry.toml
+++ b/configs/inference/sanskrit_poetry.toml
@@ -1,0 +1,9 @@
+model_name         = "Qwen/Qwen2.5-0.5B-Instruct"
+dataset = "nippun-live/sanskrit-poetry-infer-ready"
+batch_size         = 1
+dp                 = 1
+rollout_path       = "outputs"       # where infer writes checkpoints
+output_path        = "data_rollout"  # where infer writes rollouts
+clean_output_path  = false
+max_model_len      = 64
+

--- a/configs/training/sanskrit_poetry.toml
+++ b/configs/training/sanskrit_poetry.toml
@@ -1,0 +1,24 @@
+model_name = "Qwen/Qwen2.5-0.5B-Instruct"
+project    = "sanskrit-debug"
+
+[train]
+micro_bs         = 1
+attn_impl        = "flash_attention_2"
+reshard_after_forward   = false   # turn off FSDP unshard-after-forward
+torch_compile           = false   # (optional) simpler
+
+
+[optim]
+batch_size          = 1    # total samples per update (must be ≥ micro_bs and divisible)
+step_per_rollout    = 1    # how many rollouts you ingest before each optimizer step
+
+[optim.optim]
+lr                  = 1e-6
+
+[data]
+path                = "data_rollout"
+seq_length          = 64  # shrink sequence length from 2048 to 512 if needed
+
+[ckpt]
+rollout_path           = "data_rollout"
+clean_rollout_path     = false

--- a/src/zeroband/sanskrit_poetry_env.py
+++ b/src/zeroband/sanskrit_poetry_env.py
@@ -1,0 +1,64 @@
+# src/zeroband/sanskrit_poetry_env.py
+
+from typing import Dict, Any, Tuple
+from datasets import load_dataset
+from chandas import to_pattern_lines, svat_identifier
+
+class SanskritPoetryEnv:
+    def __init__(
+        self,
+        dataset_name: str = "nippun-live/sanskrit-poetry-requests",
+        max_steps: int = 10
+    ):
+        # Load the HF dataset of (topic, meter, request)
+        self.dataset = load_dataset(dataset_name)
+        self.max_steps = max_steps
+        self.current_idx = 0
+        self.current_request = None
+        self.reset()
+
+    def reset(self) -> Tuple[str, Dict[str, Any]]:
+        """Start a new episode, return (request, info)."""
+        self.current_idx = 0
+        self.current_request = self.dataset["train"][self.current_idx]
+        return (
+            self.current_request["request"],
+            {"expected_meter": self.current_request["meter"]}
+        )
+
+    def step(self, poem: str) -> Tuple[float, bool, Dict[str, Any]]:
+        lines = poem.strip().split("\n")
+        pattern_lines = to_pattern_lines(lines)
+
+        id_result = svat_identifier.IdentifyFromPatternLines(pattern_lines)
+        exact_set = id_result.get("exact", [])
+
+        if exact_set:
+            first = next(iter(exact_set))
+            if isinstance(first, tuple):
+                identified = first[0]
+            else:
+                identified = first
+        else:
+            identified = None
+
+        expected = self.current_request["meter"]
+        reward = 1.0 if (identified == expected) else -1.0
+
+        self.current_idx += 1
+        done = (
+            self.current_idx >= len(self.dataset["train"])
+            or self.current_idx >= self.max_steps
+        )
+
+        info = {"expected_meter": expected, "identified_meter": identified}
+        if not done:
+            self.current_request = self.dataset["train"][self.current_idx]
+
+        return reward, done, info
+
+
+
+    def get_current_request(self) -> str:
+        """Return the prompt (topic+meter) for the current step."""
+        return self.current_request["request"]

--- a/tests/unit/test_sanskrit_poetry_env.py
+++ b/tests/unit/test_sanskrit_poetry_env.py
@@ -1,0 +1,39 @@
+import unittest
+from src.zeroband.sanskrit_poetry_env import SanskritPoetryEnv
+
+class TestSanskritPoetryEnv(unittest.TestCase):
+    def setUp(self):
+        self.env = SanskritPoetryEnv(
+            dataset_name="nippun-live/sanskrit-poetry-requests",
+            max_steps=2
+        )
+
+    def test_reset(self):
+        req, info = self.env.reset()
+        self.assertIsInstance(req, str)
+        self.assertIn("Write a poem about", req)
+        self.assertEqual(info["expected_meter"], "Anushtup")
+
+    def test_step_incorrect_poem(self):
+        self.env.reset()
+        r, done, info = self.env.step("foo bar baz")
+        self.assertEqual(r, -1.0)
+        self.assertFalse(done)
+        self.assertIn("identified_meter", info)
+
+    def test_step_correct_meter(self):
+        # Skip the first (Anushtup) request
+        self.env.reset()
+        self.env.step("dummy text")
+
+        # Now test the known Praharṣiṇī couplet
+        stanza = (
+            "निर्दिष्टाङ् कुलपतिना स पर्णशालाम् अध्यास्य प्रयतपरिग्रहद्वितीयः ।\n"
+            "तच्छिष्याध्ययननिवेदितावसानां सव्ँविष्टः कुशशयने निशान् निनाय ॥"
+        )
+        reward, done, info = self.env.step(stanza)
+        self.assertEqual(reward, 1.0)
+        self.assertEqual(info["identified_meter"], "Praharṣiṇī")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Implemented SanskritPoetryEnv in src/zeroband/sanskrit_poetry_env.py with binary reward
- Created dataset: https://huggingface.co/datasets/nippun-live/sanskrit-poetry-requests
- Added unit tests in tests/unit/test_sanskrit_poetry_env.py
- Added configs for training/inference (training failed due to 4GB GPU OOM)